### PR TITLE
Bei fehlender Adresse, ein Informationsstring abspeichern (um NULL Co…

### DIFF
--- a/app/src/main/java/com/example/lukas/bluetoothtest/activity/MainActivity.java
+++ b/app/src/main/java/com/example/lukas/bluetoothtest/activity/MainActivity.java
@@ -294,6 +294,13 @@ public class MainActivity extends AppCompatActivity {
                     String deviceAddress = data.getExtras().getString(DeviceListActivity.EXTRA_DEVICE_ADDRESS);
                     // Adresse des zu verbindenden Gerätes
                     btdevice = btAdapter.getRemoteDevice(deviceAddress);
+                    // Falls die Pairing-Anfrage noch nicht bestätigt wurde, 2 Sekunden warten bevor versucht wird die Verbindung aufzubauen
+                    if(btdevice.getBondState() == BluetoothDevice.BOND_BONDING)
+                        try {
+                            Thread.sleep(2000);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
                     Log.e(CLASS, "Selected device:" + btdevice.getAddress() + "; " + btdevice.getAddress());
                     try{
                         // Verbindung aufbauen

--- a/app/src/main/java/com/example/lukas/bluetoothtest/activity/RunningTripActivity.java
+++ b/app/src/main/java/com/example/lukas/bluetoothtest/activity/RunningTripActivity.java
@@ -483,6 +483,9 @@ public class RunningTripActivity extends AppCompatActivity {
                         }
                     }
                 });
+        if(record.getEndAddress() == null)
+            record.setEndAddress("Keine Informationen");
+
 
         // Arraylist der Locations wird in einen String gepackt, um diesen in die DB zu schreiben
         Gson gsonRoutePoints = new Gson();

--- a/app/src/main/java/com/example/lukas/bluetoothtest/activity/StartTripActivity.java
+++ b/app/src/main/java/com/example/lukas/bluetoothtest/activity/StartTripActivity.java
@@ -196,6 +196,9 @@ public class StartTripActivity extends AppCompatActivity {
                         });
             }
 
+            if(record.getStartAddress() == null)
+                record.setStartAddress("Keine Informationen");
+
             Intent intent = new Intent(StartTripActivity.this, RunningTripActivity.class);
             startActivity(intent);
             finish();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,10 +60,10 @@
     <string name="run_init_fail">Der Bluetoothadabter konnte nicht initialisiert werden</string>
     <string name="run_init_tv">Keine Daten</string>
     <string name="run_no_data">Ihr Gerät konnte keine Daten empfangen</string>
-    <string name="run_connect">Die Verbindung zu dem OBD-Adapter wurde unterbrochen</string>
+    <string name="run_connect">Die Verbindung zu dem OBD-Adapter kann nicht hergestellt werden. Stellen Sie sicher, dass die Zündung Ihres Autos an ist</string>
     <string name="run_bt_stop">Trip stoppen</string>
     <string name="run_bt_menu">Menü</string>
-    <string name="run_no_internet">Die Karte kann wegen fehlender Internetverbindung nicht angezeigt werden</string>
+    <string name="run_no_internet">Die Route kann wegen fehlender Internetverbindung nicht angezeigt werden</string>
     <string name="run_back_msg">Wollen Sie die Aufzeichn ung der Trips wirklich unterbrechen?</string>
     <string name="run_yes">Ja</string>
     <string name="run_no">Nein</string>


### PR DESCRIPTION
…nstraint zu umgehen); Bei Koppeln mit neuem Bt-Gerät 2 Sekunden warten, um die Antwort des Pairing Requests abzuwarten